### PR TITLE
Add standardized json serialization

### DIFF
--- a/library/src/main/kotlin/com/github/ericlemieux/discogs/http/Http.kt
+++ b/library/src/main/kotlin/com/github/ericlemieux/discogs/http/Http.kt
@@ -1,6 +1,7 @@
 package com.github.ericlemieux.discogs.http
 
 import com.github.ericlemieux.discogs.authentication.Authentication
+import com.github.ericlemieux.discogs.serialization.json.Json
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -19,8 +20,8 @@ class Http(
     private val userAgent: String,
     private val domain: URL = URL(URL_BASE)
 ) {
-  private val gson: Gson =
-      GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+
+  private val json = Json()
 
   fun <T> get(route: String, c: Class<T>): Response<T> {
     val client = OkHttpClient()
@@ -36,9 +37,9 @@ class Http(
     val resJson = res.body?.string()
 
     if (!res.isSuccessful) {
-      return Response(null, gson.fromJson(resJson, Error::class.java))
+      return Response(null, json.fromString(resJson, Error::class.java))
     }
 
-    return Response(gson.fromJson(resJson, c), null)
+    return Response(json.fromString(resJson, c), null)
   }
 }

--- a/library/src/main/kotlin/com/github/ericlemieux/discogs/serialization/json/Json.kt
+++ b/library/src/main/kotlin/com/github/ericlemieux/discogs/serialization/json/Json.kt
@@ -1,0 +1,17 @@
+package com.github.ericlemieux.discogs.serialization.json
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+
+class Json {
+  private val gson =
+      GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+
+  fun <T> fromString(data: String?, c: Class<T>): T {
+    return gson.fromJson(data, c)
+  }
+
+  fun <T> toString(data: T): String {
+    return gson.toJson(data)
+  }
+}

--- a/library/src/test/kotlin/com/github/ericlemieux/discogs/database/release/ReleaseTest.kt
+++ b/library/src/test/kotlin/com/github/ericlemieux/discogs/database/release/ReleaseTest.kt
@@ -1,22 +1,20 @@
 package com.github.ericlemieux.discogs.database.release
 
-import com.google.gson.FieldNamingPolicy
-import com.google.gson.GsonBuilder
+import com.github.ericlemieux.discogs.serialization.json.Json
 import kotlin.test.assertEquals
 import org.junit.Test
 
 internal class ReleaseTest {
-  // TODO: Figure out where to put this so that it's somewhat global
-  val gson =
-      GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+
+  private val json = Json()
 
   @Test
   fun foo() {
     // Setup
-    val json = javaClass.getResource("/payloads/release-200.json").readText()
+    val payload = javaClass.getResource("/payloads/release-200.json").readText()
 
     // Act
-    val release = gson.fromJson(json, Release::class.java)
+    val release = json.fromString(payload, Release::class.java)
 
     // Verify
     assertEquals("Never Gonna Give You Up", release.title)


### PR DESCRIPTION
This should allow for some standard global settings, such as how discogs
uses lower case keys with underscores, which differs from the gson
default.